### PR TITLE
Newline Remove on Replace Bug Fix

### DIFF
--- a/drop-in
+++ b/drop-in
@@ -150,6 +150,8 @@ my $rtext = ( $opt_remove ? ""
 if ( /\n?${opt_comment}BEGIN-$key\n.*\n${opt_comment}END-$key\n/s )
 {
     debug "Replacing/Removing";
+    chomp $rtext;
+    $rtext .= "\n"; #make sure rtext has just one new line after it
     s/(${opt_comment}BEGIN-$key\n).*(${opt_comment}END-$key\n)/$rtext/s;
 }
 elsif ( ! $opt_remove )


### PR DESCRIPTION
Fixes a bug where a newline was removed when drop-in replaces an existing block in a file. Can recreate by running drop-in multiple times. This should fix it by ensuring the newline is maintained and no extra newlines leak into the file.
